### PR TITLE
Coordinator

### DIFF
--- a/api/v1/paddlejob_types.go
+++ b/api/v1/paddlejob_types.go
@@ -247,6 +247,14 @@ func (pdj *PaddleJob) GetStatuses() map[string]*ResourceStatus {
 	}
 }
 
+func (pdj *PaddleJob) GetResourceOrder() []string {
+	return []string{
+		ResourcePS,
+		ResourceWorker,
+		ResourceHeter,
+	}
+}
+
 func (pdj *PaddleJob) SetStatus(resType string, status *ResourceStatus) {
 	switch resType {
 	case ResourcePS:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,6 +46,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/exec
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - ""
+  resources:
   - pods/status
   verbs:
   - get

--- a/controllers/paddlejob_controller.go
+++ b/controllers/paddlejob_controller.go
@@ -80,6 +80,7 @@ type PaddleJobReconciler struct {
 //+kubebuilder:rbac:groups=batch.paddlepaddle.org,resources=paddlejobs/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=pods/status,verbs=get
+//+kubebuilder:rbac:groups="",resources=pods/exec,verbs=get;create
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=services/status,verbs=get
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/paddlejob_helper.go
+++ b/controllers/paddlejob_helper.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	pdv1 "github.com/paddleflow/paddle-operator/api/v1"
@@ -27,23 +28,43 @@ import (
 )
 
 const (
-	initContainerName            = "init-paddle"
 	schedulerNameVolcano         = "volcano"
 	schedulingPodGroupAnnotation = "scheduling.k8s.io/group-name"
+
+	coordContainerName  = "coord-paddle"
+	coordContainerImage = "busybox:1"
+	coordContainerCpu   = "10m"
+	coordContainerMem   = "10m"
 )
 
-func isAllPodsReady(pdj *pdv1.PaddleJob) bool {
-	specs := pdj.GetSpecs()
-	statuses := pdj.GetStatuses()
-	for k, _ := range specs {
-		if !isPodReady(specs[k], statuses[k]) {
+var (
+	coordContainerCmd = []string{"sh", "-c", "while true; do if [ -f goon ]; then exit 0; else sleep 0.1; fi; done"}
+)
+
+func isAllPodsReady(pdj *pdv1.PaddleJob, childPods corev1.PodList) bool {
+	if !isAllPodsCreated(pdj) {
+		return false
+	}
+	for _, pod := range childPods.Items {
+		if pod.Status.PodIP == "" {
 			return false
 		}
 	}
 	return true
 }
 
-func isPodReady(spec *pdv1.ResourceSpec, status *pdv1.ResourceStatus) bool {
+func isAllPodsCreated(pdj *pdv1.PaddleJob) bool {
+	specs := pdj.GetSpecs()
+	statuses := pdj.GetStatuses()
+	for k, _ := range specs {
+		if !isPodCreated(specs[k], statuses[k]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isPodCreated(spec *pdv1.ResourceSpec, status *pdv1.ResourceStatus) bool {
 	if spec == nil {
 		return true
 	}
@@ -83,10 +104,10 @@ func getPaddleJobPhase(pdj *pdv1.PaddleJob) pdv1.PaddleJobPhase {
 	for _, status := range statuses {
 		if isFailed(status) {
 			return pdv1.Failed
-		} else if isPending(status) {
-			return pdv1.Pending
 		} else if isStarting(status) {
 			return pdv1.Starting
+		} else if isPending(status) {
+			return pdv1.Pending
 		}
 	}
 	checkAll := func(check func(spec *pdv1.ResourceSpec, status *pdv1.ResourceStatus) bool) bool {
@@ -109,6 +130,49 @@ func getPaddleJobPhase(pdj *pdv1.PaddleJob) pdv1.PaddleJobPhase {
 	}
 
 	return pdj.Status.Phase
+}
+
+func isPodRealRuning(pod *corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		container := pod.Status.InitContainerStatuses[i]
+		if !container.Ready {
+			return false
+		}
+	}
+	for i := range pod.Status.ContainerStatuses {
+		container := pod.Status.ContainerStatuses[i]
+		if !container.Ready || container.State.Running == nil {
+			return false
+		}
+	}
+	return true
+}
+
+func isAllCoordContainerRunning(childPods corev1.PodList, resType string) bool {
+	for i, pod := range childPods.Items {
+		if resType == "*" || resType == pod.Annotations[pdv1.ResourceAnnotation] {
+			if !isCoordContainerRunning(&childPods.Items[i]) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isCoordContainerRunning(pod *corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodPending {
+		return false
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		container := pod.Status.InitContainerStatuses[i]
+		if container.Name == coordContainerName && container.State.Running != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func getPaddleJobStartTime(pdj *pdv1.PaddleJob) *metav1.Time {
@@ -309,7 +373,27 @@ func constructPod(pdj *pdv1.PaddleJob, resType string, idx int) (pod *corev1.Pod
 		}
 	}
 
+	coInit := genCoordinateInitContainer()
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, coInit)
+
 	return pod
+}
+
+func genCoordinateInitContainer() corev1.Container {
+	c := corev1.Container{
+		Name:            coordContainerName,
+		Image:           coordContainerImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command:         coordContainerCmd,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(coordContainerCpu),
+				corev1.ResourceMemory: resource.MustParse(coordContainerMem),
+				//corev1.ResourceEphemeralStorage: resource.MustParse(),
+			},
+		},
+	}
+	return c
 }
 
 func endpoints2hosts(eps []string) string {
@@ -346,38 +430,6 @@ func removeString(slice []string, s string) (result []string) {
 		result = append(result, item)
 	}
 	return
-}
-
-func isPodRealRuning(pod *corev1.Pod) bool {
-	if pod.Status.Phase != corev1.PodRunning {
-		return false
-	}
-	for i := range pod.Status.InitContainerStatuses {
-		container := pod.Status.InitContainerStatuses[i]
-		if !container.Ready {
-			return false
-		}
-	}
-	for i := range pod.Status.ContainerStatuses {
-		container := pod.Status.ContainerStatuses[i]
-		if !container.Ready || container.State.Running == nil {
-			return false
-		}
-	}
-	return true
-}
-
-func isPodInitializing(pod *corev1.Pod) bool {
-	if pod.Status.Phase != corev1.PodPending {
-		return false
-	}
-	for i := range pod.Status.InitContainerStatuses {
-		container := pod.Status.InitContainerStatuses[i]
-		if container.Name == initContainerName && container.State.Running != nil {
-			return true
-		}
-	}
-	return false
 }
 
 func constructService4Pod(pod corev1.Pod) *corev1.Service {

--- a/deploy/v1/operator.yaml
+++ b/deploy/v1/operator.yaml
@@ -99,6 +99,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/exec
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - ""
+  resources:
   - pods/status
   verbs:
   - get

--- a/deploy/v1beta1/operator.yaml
+++ b/deploy/v1beta1/operator.yaml
@@ -99,6 +99,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/exec
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - ""
+  resources:
   - pods/status
   verbs:
   - get

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,7 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=


### PR DESCRIPTION
paddle job will in the status *CreateContainerConfigError* after pod creating but configmap not created yet, with this pr, the creation of paddle job is a little bit different,
1. create pods, pause in init container running
2. create configmap, grap pods ip in it
3. release init container to complete in the order of resource type, for example, *ps* run ahead of *worker*
4. user container in pod running

the 3rd step is implemented with restclient and exec subresource of pod.