### PR TITLE
specify hostname and subdomain for pod

### DIFF
--- a/controllers/paddlejob_helper.go
+++ b/controllers/paddlejob_helper.go
@@ -240,6 +240,9 @@ func constructPod(pdj *pdv1.PaddleJob, resType string, idx int) (pod *corev1.Pod
 	pod.ObjectMeta.Name = name
 	pod.ObjectMeta.Namespace = pdj.Namespace
 
+	pod.Spec.Hostname = name
+	pod.Spec.Subdomain = name
+
 	envIP := corev1.EnvVar{
 		Name: "POD_IP",
 	}


### PR DESCRIPTION
specify hostname and subdomain for pod, in order to access pod through svc