### PR TITLE
set init container as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ Elastic feature depend on etcd present, which should be set for controller as ar
 
 then, job as in *deploy/elastic/resnet.yaml* can be handled correctly.
 
+### Deploy args
+Change the following args in *deploy/v1/operator.yaml* before deployment,
+```
+- args:
+  - --leader-elect             # enable leader election
+  - --namespace=paddle-system  # watch this ns only, set to "" for all namespace
+  - --scheduling=volcano       # enable volcano
+  - --initImage=""             # init container image, default to busybox, "" to disable
+  command:
+  - /manager
+```
+
 ### Uninstall
 Simply
 ```shell

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,6 @@ spec:
         - /manager
         args:
         - --leader-elect
-        - --namespace=paddle-system
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/controllers/paddlejob_helper.go
+++ b/controllers/paddlejob_helper.go
@@ -31,10 +31,9 @@ const (
 	schedulerNameVolcano         = "volcano"
 	schedulingPodGroupAnnotation = "scheduling.k8s.io/group-name"
 
-	coordContainerName  = "coord-paddle"
-	coordContainerImage = "busybox:1"
-	coordContainerCpu   = "10m"
-	coordContainerMem   = "10m"
+	coordContainerName = "coord-paddle"
+	coordContainerCpu  = "10m"
+	coordContainerMem  = "10m"
 )
 
 var (
@@ -374,13 +373,10 @@ func constructPod(pdj *pdv1.PaddleJob, resType string, idx int) (pod *corev1.Pod
 		}
 	}
 
-	coInit := genCoordinateInitContainer()
-	pod.Spec.InitContainers = append(pod.Spec.InitContainers, coInit)
-
 	return pod
 }
 
-func genCoordinateInitContainer() corev1.Container {
+func genCoordinateInitContainer(coordContainerImage string) corev1.Container {
 	c := corev1.Container{
 		Name:            coordContainerName,
 		Image:           coordContainerImage,

--- a/deploy/v1/operator.yaml
+++ b/deploy/v1/operator.yaml
@@ -240,7 +240,6 @@ spec:
       containers:
       - args:
         - --leader-elect
-        - --namespace=paddle-system
         command:
         - /manager
         image: registry.baidubce.com/paddlecloud/controller:v0.3.1

--- a/deploy/v1beta1/operator.yaml
+++ b/deploy/v1beta1/operator.yaml
@@ -240,7 +240,6 @@ spec:
       containers:
       - args:
         - --leader-elect
-        - --namespace=paddle-system
         command:
         - /manager
         image: registry.baidubce.com/paddlecloud/controller:v0.3.1

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func main() {
 	var namespace string
 	var enableLeaderElection bool
 	var scheduling string
+	var initImage string
 	var probeAddr string
 	var hostPortRange string
 	var etcdServer string
@@ -74,6 +75,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&scheduling, "scheduling", "", "The scheduler to take, e.g. volcano")
+	flag.StringVar(&initImage, "initImage", "docker.io/library/busybox:1", "The image used for init container, default to busybox")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -141,6 +143,7 @@ func main() {
 		RESTClient: restClient,
 		RESTConfig: mgr.GetConfig(),
 		Scheduling: scheduling,
+		InitImage:  initImage,
 		HostPortMap: map[string]int{
 			controllers.HOST_PORT_START: portStart,
 			controllers.HOST_PORT_CUR:   portStart,


### PR DESCRIPTION
Init container has been used to ensure the starting order of containers, this functionality can be disable and the init container image can be configured now.