### PR TITLE
use nslookup in the init container

### DIFF
--- a/controllers/paddlejob_helper.go
+++ b/controllers/paddlejob_helper.go
@@ -35,10 +35,7 @@ const (
 	coordContainerName = "coord-paddle"
 	coordContainerCpu  = "10m"
 	coordContainerMem  = "10m"
-)
-
-var (
-	coordContainerCmd = []string{"sh", "-c", "while true; do if [ -f goon ]; then exit 0; else sleep 0.1; fi; done"}
+	coordContainerSh   = "for h in %s; do for i in $(seq 1000); do echo check $i; if nslookup $h; then break; fi; if [ $i -eq 1000 ]; then exit 1; fi; sleep 1; done; done; sleep 2"
 )
 
 func isAllPodsReady(pdj *pdv1.PaddleJob, childPods corev1.PodList) bool {
@@ -376,7 +373,7 @@ func constructPod(pdj *pdv1.PaddleJob, resType string, idx int) (pod *corev1.Pod
 	return pod
 }
 
-func genCoordinateInitContainer(coordContainerImage string) corev1.Container {
+func genCoordinateInitContainer(coordContainerImage string, coordContainerCmd []string) corev1.Container {
 	c := corev1.Container{
 		Name:            coordContainerName,
 		Image:           coordContainerImage,
@@ -391,6 +388,18 @@ func genCoordinateInitContainer(coordContainerImage string) corev1.Container {
 		},
 	}
 	return c
+}
+
+func genCoordContainerCmd(pdj *pdv1.PaddleJob, resType string) []string {
+	specs := pdj.GetSpecs()
+	names := []string{}
+	for idx := 0; idx < specs[resType].Replicas; idx++ {
+		names = append(names, fmt.Sprintf("\"%s-%s-%d\"", pdj.Name, resType, idx))
+	}
+	hosts := strings.Join(names, " ")
+	sc := fmt.Sprintf(coordContainerSh, hosts)
+	ret := []string{"sh", "-c", sc}
+	return ret
 }
 
 func endpoints2hosts(eps []string) string {

--- a/controllers/paddlejob_helper.go
+++ b/controllers/paddlejob_helper.go
@@ -457,7 +457,8 @@ func constructService4Pod(pod corev1.Pod) *corev1.Service {
 			Selector: map[string]string{
 				pdv1.ResourceName: pod.Name,
 			},
-			ClusterIP: "None",
+			PublishNotReadyAddresses: true,
+			ClusterIP:                "None",
 		},
 	}
 	return svc

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&scheduling, "scheduling", "", "The scheduler to take, e.g. volcano")
-	flag.StringVar(&initImage, "initImage", "docker.io/library/alpine:3", "The image used for init container, default to alpine")
+	flag.StringVar(&initImage, "initImage", "docker.io/library/alpine:3.10", "The image used for init container, default to alpine")
 	opts := zap.Options{
 		Development: true,
 	}


### PR DESCRIPTION
### Background
To obtain the IP addresses of all pods in the same job, the paddle-operator uses an init container to perform a barrier operation. This makes it possible to collect the IP addresses of all pods and store them in a configmap that every pod can access.

### Motivation
The recent implementation relied on the `restclient` to execute remote commands, which can sometimes have issues. Therefore, we replaced this mechanism with the `nslookup` tool to perform the barrier operation. This is expected to be more reliable.

### Acknowledge 
Thank you to @lfeng-nl for testing the work and fixing the issue with the following modifications:
* The svc may not work without setting publishNotReadyAddresses=True.
* `alpine:3` does not work while `alpine:3.10` works fine.
